### PR TITLE
Ensure that release notes text is scrolled to the top

### DIFF
--- a/TWSReleaseNotesView/TWSReleaseNotesView.h
+++ b/TWSReleaseNotesView/TWSReleaseNotesView.h
@@ -8,6 +8,8 @@
 
 #import <UIKit/UIKit.h>
 
+typedef void (^TWSReleaseNotesViewCompletionHandler);
+
 /**
  Use the `TWSReleaseNotesView` class to display a custom release notes view, to be shown when the app is opened for the first time after an update.
  
@@ -87,6 +89,8 @@
 /// The shadow offset for the close button. Default is `(0.0f, -1.0f)`.
 @property (assign, nonatomic) CGSize closeButtonShadowOffset;
 
+/// A completion handler
+@property (copy, nonatomic) TWSReleaseNotesViewCompletionHandler handler;
 
 /** @name Creating the release notes view */
 

--- a/TWSReleaseNotesView/TWSReleaseNotesView.h
+++ b/TWSReleaseNotesView/TWSReleaseNotesView.h
@@ -8,7 +8,7 @@
 
 #import <UIKit/UIKit.h>
 
-typedef void (^TWSReleaseNotesViewCompletionHandler);
+typedef void (^TWSReleaseNotesViewCompletionHandler)(void);
 
 /**
  Use the `TWSReleaseNotesView` class to display a custom release notes view, to be shown when the app is opened for the first time after an update.

--- a/TWSReleaseNotesView/TWSReleaseNotesView.m
+++ b/TWSReleaseNotesView/TWSReleaseNotesView.m
@@ -377,6 +377,7 @@ static const NSTimeInterval kTWSReleaseNotesViewTransitionDuration = 0.2f;
     
     [self.textView setFont:self.releaseNotesFont];
     [self.textView setTextColor:self.releaseNotesColor];
+    [self.textView setContentOffset:CGPointMake(0, 0) animated:NO];
     [self.textView.layer setShadowColor:[self.releaseNotesShadowColor CGColor]];
     [self.textView.layer setShadowOffset:self.releaseNotesShadowOffset];
     

--- a/TWSReleaseNotesView/TWSReleaseNotesView.m
+++ b/TWSReleaseNotesView/TWSReleaseNotesView.m
@@ -467,6 +467,8 @@ static const NSTimeInterval kTWSReleaseNotesViewTransitionDuration = 0.2f;
                 if (finished)
                 {
                     [self removeFromSuperview];
+                    if (self.handler)
+                        self.handler();
                 }
             }];
         }


### PR DESCRIPTION
I am rather verbose and tend to write fairly lengthy release notes (not "War and Peace" length but maybe a page or 3 of text).  I noticed that the TWSReleaseNotesView appeared, that the release notes text appeared scrolled somewhere towards the middle of the file, and not at the top like it should be.  This patch fixes that.
